### PR TITLE
fix(ci): Use --legacy-peer-deps for npm install in CI

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'npm' # or 'yarn' if you use yarn
 
       - name: Install dependencies
-        run: npm install # or yarn install
+        run: npm install --legacy-peer-deps
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3


### PR DESCRIPTION
This resolves the ERESOLVE peer dependency errors encountered during the npm install step in the GitHub Actions workflow, primarily due to react-native-fast-image's react version incompatibility with the project's React 19.